### PR TITLE
Message Exception Handling

### DIFF
--- a/ExchangeServer/src/main/java/messenger/BuyResultMessage.java
+++ b/ExchangeServer/src/main/java/messenger/BuyResultMessage.java
@@ -78,6 +78,20 @@ public final class BuyResultMessage extends ExchangeMessage {
     }
 
     /**
+     * Construct a failure BuyResultMessage from the corresponding BuyMessage
+     * @param request The original BuyMessage
+     */
+    public BuyResultMessage(BuyMessage request) {
+        this.buyerExchange = request.buyerExchange;
+        this.buyerUserName = request.buyerUserName;
+        this.stock = request.stock;
+        this.quantityBought = 0;
+        this.totalPrice = (float) 0;
+        this.timeStamp = LocalDateTime.now();
+        this.orderID = request.orderID;
+    }
+
+    /**
      * Convert this BuyResultMessage into a list of Strings (without new-line terminators).
      * @return an ArrayList of Strings representing the information in this message instance.
      */

--- a/ExchangeServer/src/main/java/messenger/SellResultMessage.java
+++ b/ExchangeServer/src/main/java/messenger/SellResultMessage.java
@@ -80,6 +80,20 @@ public final class SellResultMessage extends ExchangeMessage {
         }
     }
 
+        /**
+     * Construct a failure SellResultMessage from the corresponding SellMessage
+     * @param request The original BuyMessage
+     */
+    public SellResultMessage(SellMessage request) {
+        this.sellerExchange = request.sellerExchange;
+        this.sellerUserName = request.sellerUserName;
+        this.stock = request.stock;
+        this.quantitySold = 0;
+        this.totalPrice = (float) 0;
+        this.timeStamp = LocalDateTime.now();
+        this.orderID = request.orderID;
+    }
+
     /**
      * Convert this SellResultMessage into a list of Strings (without new-line terminators).
      * @return an ArrayList of Strings representing the information in this message instance.

--- a/ExchangeServer/src/main/java/messenger/mutualfundmessage/MutualFundReserveResponseMessage.java
+++ b/ExchangeServer/src/main/java/messenger/mutualfundmessage/MutualFundReserveResponseMessage.java
@@ -79,6 +79,20 @@ public final class MutualFundReserveResponseMessage extends SuperPeerMessage {
     }
 
     /**
+     * Construct a failure MutualFundReserveResponseMessage from the original reserve message
+     * @param reserveMessage the original reserve message
+     */
+    public MutualFundReserveResponseMessage(MutualFundReserveMessage reserveMessage) 
+    {
+        this.superpeer = reserveMessage.superpeer;
+        this.stock = reserveMessage.stock;
+        this.quantity = 0;
+        this.timeStamp = reserveMessage.timeStamp;
+        this.orderID = reserveMessage.orderID;
+        this.reservationConfirmed = false;
+    }
+
+    /**
      * Convert this MutualFundReserveResponseMessage instance to a list of Strings (without new-line terminators).
      * @return an ArrayList of strings representing the information in this message instance.
      */

--- a/ExchangeServer/src/main/java/messenger/mutualfundmessage/MutualFundResultMessage.java
+++ b/ExchangeServer/src/main/java/messenger/mutualfundmessage/MutualFundResultMessage.java
@@ -4,6 +4,7 @@ import resourcesupport.*;
 import java.time.LocalDateTime;
 import java.util.*;
 import messenger.ExchangeMessage;
+import messenger.mutualfundmessage.MutualFundBuyMessage;
 
 /**
  * Message representing a Mutual Fund order result.
@@ -76,6 +77,20 @@ public final class MutualFundResultMessage extends ExchangeMessage {
             }
         }
     }
+
+    /**
+     * Construct a failure MutualFundResultMessage from the original buy message
+     * @param buyMessage original buy message
+     */
+    public MutualFundResultMessage(MutualFundBuyMessage buyMessage) {
+        this.buyerExchange = buyMessage.buyerExchange;
+        this.buyerUserName = buyMessage.buyerUserName;
+        this.fund = buyMessage.fund;
+        this.quantityBought = 0;
+        this.timeStamp = LocalDateTime.now();
+        this.orderID = buyMessage.orderID;
+    }
+
 
     /**
      * Convert this ResultMessage instance to a list of Strings (without new-line terminators).

--- a/ExchangeServer/src/main/java/messenger/mutualfundmessage/MutualFundUpdateMessage.java
+++ b/ExchangeServer/src/main/java/messenger/mutualfundmessage/MutualFundUpdateMessage.java
@@ -15,7 +15,6 @@ import messenger.ExchangeMessage;
 public final class MutualFundUpdateMessage extends ExchangeMessage {
     public Continent superpeer = null;
     public Stock stock = null;
-    public Integer quantity = null;
     public LocalDateTime timeStamp = null;
     public String orderID = null;
     public Boolean doCommit = null;
@@ -35,10 +34,9 @@ public final class MutualFundUpdateMessage extends ExchangeMessage {
      * @param orderID String identifier of this order
      * @param doCommit Whether the exchange should commit (true) or release (false)
      */
-    public MutualFundUpdateMessage(Continent superpeer, Stock stock, Integer quantity, LocalDateTime timeStamp, String orderID, Boolean doCommit) {
+    public MutualFundUpdateMessage(Continent superpeer, Stock stock, LocalDateTime timeStamp, String orderID, Boolean doCommit) {
         this.superpeer = superpeer;
         this.stock = stock;
-        this.quantity = quantity;
         this.timeStamp = timeStamp;
         this.orderID = orderID;
         this.doCommit = doCommit;
@@ -60,9 +58,6 @@ public final class MutualFundUpdateMessage extends ExchangeMessage {
                     break;
                 case "stock":
                     this.stock = Stock.valueOf(value);
-                    break;
-                case "quantity":
-                    this.quantity = Integer.parseInt(value);
                     break;
                 case "timeStamp":
                     this.timeStamp = LocalDateTime.parse(value);
@@ -92,9 +87,6 @@ public final class MutualFundUpdateMessage extends ExchangeMessage {
         }
         if (stock != null) {
             stringList.add("stock: " + stock);
-        }
-        if (quantity != null) {
-            stringList.add("quantity: " + quantity);
         }
         if (timeStamp != null) {
             stringList.add("timeStamp: " + timeStamp);

--- a/ExchangeServer/src/main/java/superpeer/SuperPeer.java
+++ b/ExchangeServer/src/main/java/superpeer/SuperPeer.java
@@ -19,19 +19,23 @@ public class SuperPeer extends Thread {
 	public void run() {
 		MessageQueue toSendQueue = new MessageQueue();
 		MessageQueue toProcessQueue = new MessageQueue();
+		MessageQueue exceptionQueue = new MessageQueue();
 
 		SuperPeerReceiver receiver = new SuperPeerReceiver(myExchange, toProcessQueue);
-		SuperPeerSender sender = new SuperPeerSender(myExchange, toSendQueue);
+		SuperPeerSender sender = new SuperPeerSender(myExchange, toSendQueue, exceptionQueue);
 		SuperPeerProcessor processor = new SuperPeerProcessor(myExchange, toProcessQueue, toSendQueue);
+		SuperPeerExceptionHandler handler = new SuperPeerExceptionHandler(exceptionQueue, toProcessQueue);
 
 		receiver.start();
 		sender.start();
 		processor.start();
+		handler.start();
 
 		try {
 			receiver.join();
 			sender.join();
 			processor.join();
+			handler.join();
 		}
 		catch (InterruptedException e) {
 			System.err.println("Exception in SuperPeer: " + e.getMessage());

--- a/ExchangeServer/src/main/java/superpeer/SuperPeerExceptionHandler.java
+++ b/ExchangeServer/src/main/java/superpeer/SuperPeerExceptionHandler.java
@@ -1,0 +1,44 @@
+package superpeer;
+
+import messenger.*;
+import messenger.mutualfundmessage.*;
+
+class SuperPeerExceptionHandler extends Thread {
+	private MessageQueue exceptionQueue;
+	private MessageQueue toProcessQueue;
+
+	SuperPeerExceptionHandler(MessageQueue exceptionQueue, MessageQueue toProcessQueue) {
+		this.exceptionQueue = exceptionQueue;
+		this.toProcessQueue = toProcessQueue;
+	}
+
+	public void run() {
+		while (true) {
+			Message next = exceptionQueue.take();
+			if (next instanceof ExchangeMessage)
+				handleExchangeMessage((ExchangeMessage) next);
+			else
+				handleSuperPeerMessage((SuperPeerMessage) next);
+		}
+	}
+
+	void handleExchangeMessage(ExchangeMessage next) {
+		if (next instanceof BuyMessage)
+			toProcessQueue.add(new BuyResultMessage((BuyMessage) next));
+		else if (next instanceof SellMessage) 
+			toProcessQueue.add(new SellResultMessage((SellMessage) next));
+		else if (next instanceof MutualFundReserveMessage)
+			toProcessQueue.add(new MutualFundReserveResponseMessage((MutualFundReserveMessage) next));
+		else
+			// TODO: make new sleeping-sender that waits for next-hop destination to return
+			System.err.println("Result message to " + next.getDestination() + " could not be sent");
+	}
+
+	void handleSuperPeerMessage(SuperPeerMessage next) {
+		if (next instanceof MutualFundBuyMessage)
+			toProcessQueue.add(new MutualFundResultMessage((MutualFundBuyMessage) next));
+		else
+			System.err.println("MutualFundMessage to " + next.getDestination() + " could not be sent");
+	}
+
+}

--- a/ExchangeServer/src/main/java/superpeer/SuperPeerProcessor.java
+++ b/ExchangeServer/src/main/java/superpeer/SuperPeerProcessor.java
@@ -24,7 +24,7 @@ class SuperPeerProcessor extends Thread {
 		this.toProcessQueue = toProcessQueue;
 		this.toSendQueue = toSendQueue;
 		this.myExchange = myExchange;
-		mutualManager = new MutualFundManager(toSendQueue);
+		mutualManager = new MutualFundManager(myExchange.continent(), toSendQueue);
 	}
 
 	public void run() {
@@ -68,9 +68,10 @@ class MutualFundManager {
 	MessageQueue toSendQueue;
 	Continent myContinent;
 
-	MutualFundManager(MessageQueue toSendQueue) {
+	MutualFundManager(Continent myContinent, MessageQueue toSendQueue) {
 		this.toSendQueue = toSendQueue;
 		orders = new Hashtable<String, MutualFundOrder>();
+		this.myContinent = myContinent;
 	}
 
 	void processOrder(MutualFundBuyMessage message) {
@@ -87,7 +88,6 @@ class MutualFundManager {
 	void processReserveResponse(MutualFundReserveResponseMessage message) {
 		MutualFundOrder order = orders.get(message.orderID);
 		if (null == order) {
-			System.err.println("orderID in ReserveResponse not recognized: " + message.orderID);
 			return;
 		}
 
@@ -123,7 +123,7 @@ class MutualFundManager {
 
 	void sendUpdates(String orderID, MutualFundOrder order, boolean doCommit) {
 		for (Stock stock : order.fund().stocks) {
-			toSendQueue.add(new MutualFundUpdateMessage(myContinent, stock, 0, LocalDateTime.now(), orderID, doCommit));
+			toSendQueue.add(new MutualFundUpdateMessage(myContinent, stock, LocalDateTime.now(), orderID, doCommit));
 		}
 	}
 }

--- a/ExchangeServer/src/main/java/superpeer/SuperPeerSender.java
+++ b/ExchangeServer/src/main/java/superpeer/SuperPeerSender.java
@@ -10,11 +10,13 @@ import java.util.ArrayList;
 // Class that sends messages from send queue to other peers
 public class SuperPeerSender extends Thread {
 	private MessageQueue toSendQueue;
+	private MessageQueue exceptionQueue;
 	private Exchange myExchange;
 
-	SuperPeerSender(Exchange myExchange, MessageQueue toSendQueue) {
+	SuperPeerSender(Exchange myExchange, MessageQueue toSendQueue, MessageQueue exceptionQueue) {
 		this.toSendQueue = toSendQueue;
 		this.myExchange = myExchange;
+		this.exceptionQueue = exceptionQueue;
 	}
 
 	public void run() {
@@ -34,8 +36,7 @@ public class SuperPeerSender extends Thread {
 				out.println();
 			}
 			catch (Exception e) {
-				System.out.println("Message destined for port " + destinationPort 
-					+ " could not be sent.");
+				exceptionQueue.add(next);
 			}
 		}
 	}
@@ -51,7 +52,12 @@ public class SuperPeerSender extends Thread {
 			return getExchangeNextPort(destinationExchange);
 		}
 		else {
-			Continent destinationContinent = ((SuperPeerMessage)next).getDestination();
+			Continent destinationContinent = ((SuperPeerMessage) next).getDestination();
+			if (destinationContinent == null) {
+				System.out.println("no destination?");
+				next.print();
+			}
+
 			return getContinentNextPort(destinationContinent);
 		}
 	}

--- a/ExchangeServer/src/main/java/superpeertest/SuperPeerTest.java
+++ b/ExchangeServer/src/main/java/superpeertest/SuperPeerTest.java
@@ -24,11 +24,11 @@ public class SuperPeerTest {
 		nySuper.start();
 		johanSuper.start();
 		hkSuper.start();
-		londonRec.start();
-		nyseRec.start();
-		parisRec.start();
-		frankfurtRec.start();
-		tokyoRec.start();
+		// londonRec.start();
+		// nyseRec.start();
+		// parisRec.start();
+		// frankfurtRec.start();
+		// tokyoRec.start();
 
 
 		Thread.sleep(1000);
@@ -43,14 +43,14 @@ public class SuperPeerTest {
 		londonSender.send(buyMsg);
 		Thread.sleep(1000);
 
-		for (Stock stock : MutualFund.BANKING.stocks)
-			londonSender.send(new MutualFundReserveResponseMessage(Continent.EUROPE, stock, 20, LocalDateTime.now(), "0", true));
+		// for (Stock stock : MutualFund.BANKING.stocks)
+		// 	londonSender.send(new MutualFundReserveResponseMessage(Continent.EUROPE, stock, 20, LocalDateTime.now(), "0", false));
 
 		// londonSender.send(resMsg);
 		// londonSender.send(updateMsg);
 		// Thread.sleep(1000);
 		// londonSender.send(updateMsg);
-		Thread.sleep(1000);
+		// Thread.sleep(1000);
 		londonRec.printLog();
 		parisRec.printLog();
 		frankfurtRec.printLog();


### PR DESCRIPTION
Added failure recovery for when an adjacent node can’t be contacted
when sending a message.  If the message is a request (buy, sell), then
a failure result is sent back to the originator.